### PR TITLE
Add passphrase to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to Remote
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          passphrase: ${{ secrets.SSH_PASSPHRASE }}
+          port: ${{ secrets.SSH_PORT }}
+          script: |
+            cd tastify
+            git fetch
+            git reset --hard origin/${{ github.ref_name }}
+            docker compose --file ./docker/remote.docker-compose.yaml stop
+            docker compose --file ./docker/remote.docker-compose.yaml up --build -d
+

--- a/README.md
+++ b/README.md
@@ -15,10 +15,22 @@ open http://localhost:5173
 ```
 
 ## Deploying the App
-Update remote through ssh
+Update the remote server manually with:
 ```bash
 bash ./scripts/update_remote.sh
 ```
+Deployment is also triggered automatically by GitHub Actions when pushing to
+`main` or updating a pull request. The workflow connects to the server over SSH
+and runs the same update commands.
+
+The following secrets must be configured in your repository under **Settings →
+Secrets and variables → Actions**:
+
+- `SSH_HOST`
+- `SSH_PORT`
+- `SSH_USER`
+- `SSH_PRIVATE_KEY`
+- `SSH_PASSPHRASE`
 
 ## Test
 1. Install requirements


### PR DESCRIPTION
## Summary
- run the deploy workflow on PR updates
- add `SSH_PASSPHRASE` secret input for encrypted SSH keys
- document required secrets in README

## Testing
- `bash ./scripts/local-install.sh` *(fails: could not download litestar)*
- `pytest back` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6839df7b1c40832ea9a9913221d42298