### PR TITLE
Fix container deployment issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,13 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           script: |
             cd tastify
-            git fetch
-            git reset --hard origin/${{ github.ref_name }}
+            git fetch --depth=1 origin ${{ github.sha }}
+            git reset --hard ${{ github.sha }}
             docker compose --file ./docker/remote.docker-compose.yaml stop
-            docker compose --file ./docker/remote.docker-compose.yaml up --build -d
+            docker container prune -f
+            docker volume prune -f
+            docker compose --file ./docker/remote.docker-compose.yaml up --build -d || {
+              docker compose --file ./docker/remote.docker-compose.yaml logs --tail=50 migrate
+              exit 1
+            }
 

--- a/scripts/update_remote.sh.tpl
+++ b/scripts/update_remote.sh.tpl
@@ -8,4 +8,9 @@ git fetch
 git reset --hard origin/BRANCH_NAME
 
 docker compose --file ./docker/remote.docker-compose.yaml stop
-docker compose --file ./docker/remote.docker-compose.yaml up --build -d
+docker container prune -f
+docker volume prune -f
+docker compose --file ./docker/remote.docker-compose.yaml up --build -d || {
+  docker compose --file ./docker/remote.docker-compose.yaml logs --tail=50 migrate
+  exit 1
+}


### PR DESCRIPTION
## Summary
- prune old containers and volumes to free up space before starting containers
- use commit SHA when resetting repo to handle refs without remote branches
- show migrate service logs if compose fails

## Testing
- `pytest -q back/tests` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*


------
https://chatgpt.com/codex/tasks/task_e_683a01330f24832ea6879aee644a527e