### PR TITLE
Fix container deployment issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,5 +23,7 @@ jobs:
             git fetch
             git reset --hard origin/${{ github.ref_name }}
             docker compose --file ./docker/remote.docker-compose.yaml stop
+            docker container prune -f
+            docker volume prune -f
             docker compose --file ./docker/remote.docker-compose.yaml up --build -d
 

--- a/docker/local.docker-compose.yaml
+++ b/docker/local.docker-compose.yaml
@@ -20,6 +20,7 @@ services:
     build:
       context: ..
       dockerfile: docker/back.dockerfile
+    env_file: "../.env"
     environment:
       DB_URL: "postgresql+asyncpg://postgres@db:5432/postgres"
     depends_on:

--- a/docker/remote.docker-compose.yaml
+++ b/docker/remote.docker-compose.yaml
@@ -20,6 +20,7 @@ services:
     build:
       context: ..
       dockerfile: docker/back.dockerfile
+    env_file: "/home/tastify/.env"
     environment:
       DB_URL: "postgresql+asyncpg://postgres@db:5432/postgres"
     depends_on:


### PR DESCRIPTION
## Summary
- prune old containers and volumes to free up space before starting containers
- set env_file for migrate service

## Testing
- `pytest -q back/tests` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*


------
https://chatgpt.com/codex/tasks/task_e_683a01330f24832ea6879aee644a527e