### PR TITLE
Fix migrate env_file

### DIFF
--- a/docker/local.docker-compose.yaml
+++ b/docker/local.docker-compose.yaml
@@ -20,6 +20,7 @@ services:
     build:
       context: ..
       dockerfile: docker/back.dockerfile
+    env_file: "../.env"
     environment:
       DB_URL: "postgresql+asyncpg://postgres@db:5432/postgres"
     depends_on:

--- a/docker/remote.docker-compose.yaml
+++ b/docker/remote.docker-compose.yaml
@@ -20,6 +20,7 @@ services:
     build:
       context: ..
       dockerfile: docker/back.dockerfile
+    env_file: "/home/tastify/.env"
     environment:
       DB_URL: "postgresql+asyncpg://postgres@db:5432/postgres"
     depends_on:


### PR DESCRIPTION
## Summary
- add missing `env_file` to migrate service in both compose files

## Testing
- `bash ./scripts/local-install.sh` *(fails: Could not fetch litestar)*

------
https://chatgpt.com/codex/tasks/task_e_683a0e710ae0832e8cd6d05038b8d06b