### PR TITLE
Fix migrate env_file

### DIFF
--- a/docker/local.docker-compose.yaml
+++ b/docker/local.docker-compose.yaml
@@ -3,9 +3,10 @@ services:
   db:
     image: postgres:15
     environment:
-      - POSTGRES_HOST_AUTH_METHOD=trust
+      POSTGRES_USER: test_user
+      POSTGRES_PASSWORD: test_password
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata2:/var/lib/postgresql/data
     ports:
       - "5432:5432"
     expose:
@@ -20,8 +21,9 @@ services:
     build:
       context: ..
       dockerfile: docker/back.dockerfile
+    env_file: "../.env"
     environment:
-      DB_URL: "postgresql+asyncpg://postgres@db:5432/postgres"
+      DB_URL: "postgresql+asyncpg://test_user:test_password@db:5432/postgres"
     depends_on:
       db:
         condition: service_healthy
@@ -35,7 +37,7 @@ services:
       dockerfile: docker/back.dockerfile
     env_file: "../.env"
     environment:
-      DB_URL: "postgresql+asyncpg://postgres@db:5432/postgres"
+      DB_URL: "postgresql+asyncpg://test_user:test_password@db:5432/postgres"
     depends_on:
       db:
         condition: service_healthy
@@ -71,4 +73,4 @@ services:
 
 
 volumes:
-  pgdata:
+  pgdata2:

--- a/docker/remote.docker-compose.yaml
+++ b/docker/remote.docker-compose.yaml
@@ -3,9 +3,10 @@ services:
   db:
     image: postgres:15
     environment:
-      - POSTGRES_HOST_AUTH_METHOD=trust
+      POSTGRES_USER: test_user
+      POSTGRES_PASSWORD: test_password
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata2:/var/lib/postgresql/data
     ports:
       - "5432:5432"
     expose:
@@ -20,8 +21,9 @@ services:
     build:
       context: ..
       dockerfile: docker/back.dockerfile
+    env_file: "/home/tastify/.env"
     environment:
-      DB_URL: "postgresql+asyncpg://postgres@db:5432/postgres"
+      DB_URL: "postgresql+asyncpg://test_user:test_password@db:5432/postgres"
     depends_on:
       db:
         condition: service_healthy
@@ -33,7 +35,7 @@ services:
       dockerfile: docker/back.dockerfile
     env_file: "/home/tastify/.env"
     environment:
-      DB_URL: "postgresql+asyncpg://postgres@db:5432/postgres"
+      DB_URL: "postgresql+asyncpg://test_user:test_password@db:5432/postgres"
     depends_on:
       db:
         condition: service_healthy
@@ -56,4 +58,4 @@ services:
 
 
 volumes:
-  pgdata:
+  pgdata2:


### PR DESCRIPTION
## Summary
- add missing `env_file` to migrate service in both compose files
- set explicit test creds for DB and rename postgres volume so new one is used

## Testing
- `bash ./scripts/local-install.sh` *(fails: Could not fetch litestar)*

------
https://chatgpt.com/codex/tasks/task_e_683a0e710ae0832e8cd6d05038b8d06b