### PR TITLE
Fix logs in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,8 +25,8 @@ jobs:
             docker compose --file ./docker/remote.docker-compose.yaml stop
             docker container prune -f
             docker volume prune -f
-            docker compose --file ./docker/remote.docker-compose.yaml up --build -d || {
-              docker compose --file ./docker/remote.docker-compose.yaml logs --tail=50 migrate
-              exit 1
-            }
+              docker compose --file ./docker/remote.docker-compose.yaml up --build -d || {
+                docker compose --file ./docker/remote.docker-compose.yaml logs --tail=200
+                exit 1
+              }
 

--- a/scripts/update_remote.sh.tpl
+++ b/scripts/update_remote.sh.tpl
@@ -11,6 +11,6 @@ docker compose --file ./docker/remote.docker-compose.yaml stop
 docker container prune -f
 docker volume prune -f
 docker compose --file ./docker/remote.docker-compose.yaml up --build -d || {
-  docker compose --file ./docker/remote.docker-compose.yaml logs --tail=50 migrate
+  docker compose --file ./docker/remote.docker-compose.yaml logs --tail=200
   exit 1
 }


### PR DESCRIPTION
## Summary
- show logs for all containers after failed deployment
- bump log line limit to 200

## Testing
- `pytest -q back` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_683b8b24e2a4832ebdcefdcade65f6c1