### PR TITLE
Fix DB healthcheck username

### DIFF
--- a/docker/local.docker-compose.yaml
+++ b/docker/local.docker-compose.yaml
@@ -12,7 +12,7 @@ services:
     expose:
       - "5432"
     healthcheck:
-      test: "psql -U postgres -c 'select 1'"
+      test: ["CMD-SHELL", "psql -U $${POSTGRES_USER} -c 'select 1'"]
       interval: 1s
       timeout: 5s
       retries: 10

--- a/docker/remote.docker-compose.yaml
+++ b/docker/remote.docker-compose.yaml
@@ -12,7 +12,7 @@ services:
     expose:
       - "5432"
     healthcheck:
-      test: "psql -U postgres -c 'select 1'"
+      test: ["CMD-SHELL", "psql -U $${POSTGRES_USER} -c 'select 1'"]
       interval: 1s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## Summary
- use POSTGRES_USER env var in db container healthcheck

## Testing
- `make -C back test` *(fails: `.venv/bin/pytest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b904bf250832ea984e1615d24c7dc